### PR TITLE
fix: update async implementation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4,14 +4,14 @@ namespace Rider.Mac.Debug.Perf.Example;
 
 public abstract class Program
 {
-    private static void Main()
+    private static async Task Main()
     {
         var stopwatch = new Stopwatch();
         stopwatch.Start();
-        RunParallelFibonacciTasks();
+        await RunParallelFibonacciTasks();
         Console.WriteLine($"RunParallelFibonacciTasks time elapsed: {stopwatch.Elapsed}");
         stopwatch.Restart();
-        RunParallelHttpRequests();
+        await RunParallelHttpRequests();
         Console.WriteLine($"RunParallelHttpRequests time elapsed: {stopwatch.Elapsed}");
         stopwatch.Stop();
     }
@@ -19,7 +19,7 @@ public abstract class Program
     /// <summary>
     /// Run multiple Fibonacci tasks in parallel.
     /// </summary>
-    private static void RunParallelFibonacciTasks()
+    private static async Task RunParallelFibonacciTasks()
     {
         int Fibonacci(int n)
         {
@@ -37,19 +37,19 @@ public abstract class Program
             {
                 for (var n = 1; n <= 40; n++)
                 {
-                    var result = Fibonacci(n);
+                    Fibonacci(n);
                     // Console.WriteLine($"Task {Task.CurrentId}: Fibonacci({n}) = {result}");
                 }
             }));
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks.ToArray());
     }
 
     /// <summary>
     /// Run multiple HTTP requests in parallel.
     /// </summary>
-    private static void RunParallelHttpRequests()
+    private static async Task RunParallelHttpRequests()
     {
         var client = new HttpClient();
         var tasks = new List<Task>();
@@ -64,6 +64,6 @@ public abstract class Program
             }));
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks.ToArray());
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ This example project tries to reproduce the issue.
 
 #### Rider
 * Run:
-  * `RunParallelFibonacciTasks time elapsed: 00:00:03.3856167`
-  * `RunParallelHttpRequests time elapsed: 00:00:00.2774819`
+  * `RunParallelFibonacciTasks time elapsed: 00:00:04.8026837`
+  * `RunParallelHttpRequests time elapsed: 00:00:00.3663711`
 * Debug:
-  * `RunParallelFibonacciTasks time elapsed: 00:00:10.2523595`
-  * `RunParallelHttpRequests time elapsed: 00:00:00.5442160`
+  * `RunParallelFibonacciTasks time elapsed: 00:00:14.5348484`
+  * `RunParallelHttpRequests time elapsed: 00:00:01.0609222`
 
 #### VSCode
-* Run: 
-  * `RunParallelFibonacciTasks time elapsed: 00:00:02.2992337`
-  * `RunParallelHttpRequests time elapsed: 00:00:00.2039228`
-* Debug: 
-  * `RunParallelFibonacciTasks time elapsed: 00:00:10.2194985`
-  * `RunParallelHttpRequests time elapsed: 00:00:00.3564102`
+* Run:
+  * `RunParallelFibonacciTasks time elapsed: 00:00:04.3853632`
+  * `RunParallelHttpRequests time elapsed: 00:00:00.3147610`
+* Debug:
+  * `RunParallelFibonacciTasks time elapsed: 00:00:04.3754359`
+    `RunParallelHttpRequests time elapsed: 00:00:00.2788305`


### PR DESCRIPTION
The original async implementation of this program hides all of the async work behind a blocking call, which seems to mask the problem.  To force this issue into the open, you need to await it on the main thread.  This creates a Task that will complete when all of the supplied tasks have completed and awaiting that array of Tasks exposes the problem.  If you put it behing `Task.WaitAll`, the debugger seems to handle the blocking call differently than the await.